### PR TITLE
Add deps as a dependency to prepare

### DIFF
--- a/cli/src/Makefile
+++ b/cli/src/Makefile
@@ -18,7 +18,7 @@ all: linux darwin windows
 deps:
 	git submodule init && git submodule update
 
-prepare:
+prepare: deps
 	GOPATH=$(GOPATH) go env
 
 linux: prepare


### PR DESCRIPTION
All of the makefile targets require deps to run, adding it as a dependency
to prepare will fix the make targets.