### PR TITLE
Clear system properties in SecurityUtilsTest

### DIFF
--- a/common/src/test/java/com/vmware/admiral/common/util/SecurityUtilsTest.java
+++ b/common/src/test/java/com/vmware/admiral/common/util/SecurityUtilsTest.java
@@ -75,6 +75,9 @@ public class SecurityUtilsTest {
         assertNotNull(disabledAlgorithms);
         assertFalse(disabledAlgorithms.contains("TLSv1,"));
         assertFalse(disabledAlgorithms.contains("TLSv1.1,"));
+
+        System.setProperty("com.vmware.admiral.enable.tlsv1", Boolean.FALSE.toString());
+        System.setProperty("com.vmware.admiral.enable.tlsv1.1", Boolean.FALSE.toString());
     }
 
     @Test
@@ -171,6 +174,10 @@ public class SecurityUtilsTest {
         securityProperties = System.getProperty(SECURITY_PROPERTIES);
         assertNotNull(securityProperties);
         assertEquals(securityPropertiesValue, securityProperties);
+
+        System.clearProperty(JAVAX_NET_SSL_TRUST_STORE);
+        System.clearProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD);
+        System.clearProperty(SECURITY_PROPERTIES);
     }
 
 }


### PR DESCRIPTION
The tests `com.vmware.admiral.common.util.SecurityUtilsTest.testEnsureTrustStoreSettings` and `com.vmware.admiral.common.util.SecurityUtilsTest.testEnsureTlsDisabledAlgorithms` are not idempotent and fail if run twice in the same JVM, because each of the tests pollutes some states(system properties) shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

The suggested fix to clear the system properties that are set in the tests when each test finishes.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).