### PR TITLE
Clear MockKubernetesAdapterService.requestOnInspect in KubernetesMaintenanceTest

### DIFF
--- a/adapter/kubernetes/src/test/java/com/vmware/admiral/adapter/kubernetes/KubernetesMaintenanceTest.java
+++ b/adapter/kubernetes/src/test/java/com/vmware/admiral/adapter/kubernetes/KubernetesMaintenanceTest.java
@@ -76,6 +76,7 @@ public class KubernetesMaintenanceTest extends ComputeBaseTest {
                 .requestOnInspect.operationTypeId);
         assertEquals(podState.documentSelfLink, MockKubernetesAdapterService.requestOnInspect
                 .resourceReference.getPath());
+        MockKubernetesAdapterService.requestOnInspect = null;
     }
 
 }


### PR DESCRIPTION
The test `com.vmware.admiral.adapter.kubernetes.KubernetesMaintenanceTest.testAdapterRequestOnPeriodicMaintenance` is not idempotent and fail if run twice in the same JVM, because it pollutes some states shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Detail
Running `KubernetesMaintenanceTest.testAdapterRequestOnPeriodicMaintenance` twice would result in the second run failing due to the following assertion error:
```
assertEquals(podState.documentSelfLink, MockKubernetesAdapterService.requestOnInspect.resourceReference.getPath());
```
The root cause is that the static`MockKubernetesAdapterService.requestOnInspect` variable is set during the first test run, but doesn't get cleared upon test exits.

The suggested fix is to clear the static variable `MockKubernetesAdapterService.requestOnInspect` set during the test when the test finishes.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).