### PR TITLE
Clear MockKubernetesApplicationAdapterService.CREATED_DEPLOYMENT_STATES in RequestBrokerKubernetesServiceTest

### DIFF
--- a/compute/src/main/java/com/vmware/admiral/service/kubernetes/test/MockKubernetesApplicationAdapterService.java
+++ b/compute/src/main/java/com/vmware/admiral/service/kubernetes/test/MockKubernetesApplicationAdapterService.java
@@ -312,5 +312,6 @@ public class MockKubernetesApplicationAdapterService extends BaseMockAdapterServ
 
     public static void clear() {
         PROVISIONED_COMPONENTS.clear();
+        CREATED_DEPLOYMENT_STATES.clear();
     }
 }


### PR DESCRIPTION
The test `com.vmware.admiral.request.kubernetes.RequestBrokerKubernetesServiceTest.testRequestStateHasK8sInfo` is not idempotent and fail if run twice in the same JVM, because it pollutes some states shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Detail
Running `RequestBrokerKubernetesServiceTest.testRequestStateHasK8sInfo` twice would result in the second run failing due to the following assertion error:
```
assertEquals(numberOfDeployments, MockKubernetesApplicationAdapterService.getCreatedDeploymentStates().size());
```
The root cause is that the static`MockKubernetesApplicationAdapterService.CREATED_DEPLOYMENT_STATES` is updated during the first test run, but doesn't get cleared upon test exits.

The suggested fix is to clear the static variable `MockKubernetesApplicationAdapterService.CREATED_DEPLOYMENT_STATES` in `MockKubernetesApplicationAdapterService.clear()`, which is already invoked in the `setup()` function. This will ensure that this static variable is reset before each test is run.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).