### PR TITLE
Reset path to avoid flaky tests

### DIFF
--- a/common/src/test/java/com/vmware/admiral/common/util/ReflectionUtilsTest.java
+++ b/common/src/test/java/com/vmware/admiral/common/util/ReflectionUtilsTest.java
@@ -33,6 +33,8 @@ public class ReflectionUtilsTest {
         ReflectionUtils.setAnnotation(DummyClass.class, Path.class, new CustomPath("/bar"));
 
         assertEquals("/bar", DummyClass.class.getAnnotation(Path.class).value());
+
+        ReflectionUtils.setAnnotation(DummyClass.class, Path.class, new CustomPath("/foo"));
     }
 
 }


### PR DESCRIPTION
## What is the purpose of this change
This PR cleans the state pollued by the test `com.vmware.admiral.common.util.ReflectionUtilsTest.testSetPathAnnotation`.

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
## Reproduce test failure
Run the test twice in the same JVM. 
## Expected result:
The tests should run successfully when multiple tests that use this state are run in the same JVM.
## Actual result:
We get failure:
`Failed tests: 
  ReflectionUtilsTest.testSetPathAnnotation:32 expected:</[foo]> but was:</[bar]>`
## Why the test fails
The path was changed to `/bar`.
## Fix
Reset the path to `/foo`.